### PR TITLE
get port from env variable

### DIFF
--- a/emmer.go
+++ b/emmer.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"log/slog"
 	"net/http"
+	"os"
 
 	server "github.com/TimoKats/emmer/server"
 )
@@ -14,8 +15,11 @@ type flags struct {
 }
 
 func getFlags() flags {
-	port := flag.String("p", "8080", "Port.")
+	port := flag.String("p", "2112", "Port.")
 	flag.Parse()
+	if envPort := os.Getenv("EM_PORT"); server.ValidPort(envPort) {
+		port = &envPort
+	}
 	return flags{port: ":" + *port}
 }
 

--- a/server/utils.go
+++ b/server/utils.go
@@ -16,6 +16,15 @@ import (
 	"strings"
 )
 
+// used to check EM_PORT value
+func ValidPort(s string) bool {
+	port, err := strconv.Atoi(s)
+	if err != nil {
+		return false
+	}
+	return port >= 1 && port <= 65535
+}
+
 // get HTTP request and format it into Request object used by server
 func parseRequest(r *http.Request) (Request, error) {
 	request := Request{Method: r.Method, Mode: r.FormValue("mode")}


### PR DESCRIPTION
This pull request updates the way the server port is configured, allowing it to be set via an environment variable and ensuring the value is valid. The default port is also changed. These improvements make the application more flexible and robust in different deployment environments.

Configuration and environment support:

* Added support for configuring the server port using the `EM_PORT` environment variable, with validation to ensure the port is within the valid range. (`emmer.go`, `server/utils.go`) [[1]](diffhunk://#diff-c0741924fee0f313a1db60527d1177d912916b6d9f193f36607dcaa78c26d9bdL17-R22) [[2]](diffhunk://#diff-83128e04e7c4b9c74124eff5b02d62ea8a65d23cb4b585ad782a3ebb276fe898R19-R27)
* Changed the default server port from `8080` to `2112` for consistency with the new configuration approach. (`emmer.go`)

Dependency management:

* Imported the `os` package in `emmer.go` to enable reading environment variables. (`emmer.go`)